### PR TITLE
Update Miryoku

### DIFF
--- a/src/posts/manna_harbour.md
+++ b/src/posts/manna_harbour.md
@@ -1,7 +1,7 @@
 ---
 author: manna-harbour
 baseLayouts: [AZERTY,BEAKL,Colemak,Dvorak,Halmak,Workman,QWERTY,QWERTZ]
-firmwares: [QMK, KMonad]
+firmwares: [QMK, ZMK, KMonad]
 hasHomeRowMods: true
 hasLetterOnThumb: false
 hasRotaryEncoder: false
@@ -9,13 +9,13 @@ isAutoShiftEnabled: true
 isComboEnabled: false
 isSplit: true
 isTapDanceEnabled: false
-keybindings: [Vim,Emacs,TWM]
+keybindings: [Vim,Emacs,TWM,Gaming]
 keyboard: MiniDox
 keyCount: 36
 keymapImage: https://raw.githubusercontent.com/manna-harbour/miryoku/master/data/cover/miryoku-kle-cover.png
 keymapUrl: https://github.com/manna-harbour/miryoku_qmk/tree/miryoku/users/manna-harbour_miryoku
 languages: [English]
-layerCount: 8
+layerCount: 10
 OS: [Linux,Windows,MacOS]
 stagger: columnar
 summary: Miryoku is an ergonomic, minimal, orthogonal, and universal keyboard layout.


### PR DESCRIPTION
- Add ZMK to firmwares list. Miryoku ZMK is now available.
  https://github.com/manna-harbour/miryoku_zmk.
- Add Gaming to keybindings list. Tap (gaming) layer is now included.
  https://github.com/manna-harbour/miryoku/tree/master/docs/reference#additional-features
- Increase layerCount to 10. Extra and Tap layers have been added.
  https://github.com/manna-harbour/miryoku/tree/master/docs/reference#additional-features