### PR TITLE
Update caksoylar's keymap

### DIFF
--- a/src/posts/keymaps/caksoylar.md
+++ b/src/posts/keymaps/caksoylar.md
@@ -10,7 +10,7 @@ isComboEnabled: true
 isSplit: true
 isTapDanceEnabled: false
 keybindings: [Gaming, Kakoune, Vim]
-keyboard: "Hummingbird"
+keyboard: "Corne"
 keyCount: 30
 keymapImage: https://caksoylar.github.io/zmk-config/3x5+3.30keys.svg
 keymapUrl: https://github.com/caksoylar/zmk-config

--- a/src/posts/keymaps/caksoylar.md
+++ b/src/posts/keymaps/caksoylar.md
@@ -1,24 +1,24 @@
 ---
 author: caksoylar
-baseLayouts: [QWERTY, Colemak]
+baseLayouts: [Colemak, APT]
 firmwares: [ZMK, QMK]
 hasHomeRowMods: true
 hasLetterOnThumb: false
-hasRotaryEncoder: true
+hasRotaryEncoder: false
 isAutoShiftEnabled: false
 isComboEnabled: true
 isSplit: true
 isTapDanceEnabled: false
 keybindings: [Gaming, Kakoune, Vim]
-keyboard: "Hypergolic"
-keyCount: 34
-keymapImage: https://caksoylar.github.io/zmk-config/3x5.full.svg
+keyboard: "Hummingbird"
+keyCount: 30
+keymapImage: https://caksoylar.github.io/zmk-config/3x5+3.30keys.svg
 keymapUrl: https://github.com/caksoylar/zmk-config
 languages: [English]
 layerCount: 6
-OS: [Linux, Windows]
+OS: [Windows, Linux]
 stagger: columnar
-summary: This is a ZMK and QMK config for my 34-36 key split keyboards, arranged in 3 rows of 5 columns with 2 or 3 thumb keys on each side. It uses three non-base layers activated through two thumb keys along with combos. It has <kbd>Ctrl</kbd>/<kbd>Shift</kbd> thumb hold-taps along with home row mods. <code>FUN</code> layer is implemented as a tri-layer.
-title: caksoylar's keymap for 34–36 key keyboards
+summary: This is a ZMK and QMK config for my 30-36 key split keyboards, scaling from 5-column 3-thumb layouts down to Hummingbird-like `23332+2` layouts. Base layers include a Colemak variation and an APT variation, utilizing combos for frequent symbols and infrequent letters.
+title: caksoylar's keymap for 30–36 key keyboards
 writeup: https://github.com/caksoylar/zmk-config/blob/main/README.md
 ---


### PR DESCRIPTION
Updating for my layout overhaul to be compatible with 30 key keyboards, and added mouse layer.

Although my QMK userspace technically has a rotary encoder in the Iris keymap, it isn't in any of my daily "typing" boards using this layout so I think I'd count this as a no rotary encoder keymap.

For the keyboard I selected Hummingbird since that is closest to the physical layout for the minimum key count and it was already in the DB. However I don't have that keyboard or another with 30 keys, I assume that's OK? I am mainly using a Corne-ish Zen with the 30 key subset at the moment.
