### PR TITLE
Add haunt98 keymap for D60Lite

### DIFF
--- a/src/posts/keymaps/haunt98.md
+++ b/src/posts/keymaps/haunt98.md
@@ -18,7 +18,7 @@ languages: [English]
 layerCount: 4
 OS: [MacOS, Linux]
 stagger: row
-summary: HHKB variant with QMK features: Grave Escape, Mod-Tap, Space Cadet, Tap Dance
+summary: HHKB variant with QMK features Grave Escape, Mod-Tap, Space Cadet, Tap Dance
 title: haunt98's keymap for D60Lite
 writeup: https://github.com/haunt98/qmk_keymaps/blob/main/README.md
 ---

--- a/src/posts/keymaps/haunt98.md
+++ b/src/posts/keymaps/haunt98.md
@@ -18,7 +18,7 @@ languages: [English]
 layerCount: 4
 OS: [MacOS, Linux]
 stagger: row
-summary: HHKB variant with Grave Escape, Mod-Tap, Space Cadet, Tap Dance
+summary: HHKB variant with QMK features: Grave Escape, Mod-Tap, Space Cadet, Tap Dance
 title: haunt98's keymap for D60Lite
 writeup: https://github.com/haunt98/qmk_keymaps/blob/main/README.md
 ---

--- a/src/posts/keymaps/haunt98.md
+++ b/src/posts/keymaps/haunt98.md
@@ -1,0 +1,24 @@
+---
+author: haunt98
+baseLayouts: [QWERTY]
+firmwares: [QMK]
+hasHomeRowMods: false
+hasLetterOnThumb: false
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: false
+isSplit: false
+isTapDanceEnabled: true
+keybindings: [Vim]
+keyboard: D60Lite
+keyCount: 60
+keymapImage: https://raw.githubusercontent.com/haunt98/qmk_keymaps/main/dztech_dz60rgb_wkl/caksoylar_keymap_drawer/keymap.svg
+keymapUrl: https://github.com/haunt98/qmk_keymaps/tree/main/dztech_dz60rgb_wkl/keymaps/haunt98
+languages: [English]
+layerCount: 4
+OS: [MacOS, Linux]
+stagger: row
+summary: HHKB variant with Grave Escape, Mod-Tap, Space Cadet, Tap Dance
+title: haunt98's keymap for D60Lite
+writeup: https://github.com/haunt98/qmk_keymaps/blob/main/README.md
+---


### PR DESCRIPTION
Add my variant for D60Lite, which is based on HHKB and QMK feature.