### PR TITLE
Planck Unicode Rune layout

### DIFF
--- a/src/posts/keymaps/trguhq.md
+++ b/src/posts/keymaps/trguhq.md
@@ -1,0 +1,24 @@
+---
+author: trguhq
+baseLayouts: []
+firmwares: [QMK]
+hasHomeRowMods: false
+hasLetterOnThumb: false
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: false
+isSplit: false
+isTapDanceEnabled: false
+keybindings: []
+keyboard: Planck
+keyCount: 48
+keymapImage: "https://i.imgur.com/ocILTZ3.png"
+keymapUrl: "https://github.com/trguhq/planck_rune"
+languages: [Danish, English, Faroese, Icelandic, Norwegian, Swedish] 
+layerCount: 7
+OS: [Windows, MacOS, Linux]
+stagger: ortholinear
+summary: "QMK Unicode Rune (Futhark) Layout for Planck and other 4x12 Ortho Keyboards"
+title: "Planck Unicode Rune"
+writeup: "https://github.com/trguhq/planck_rune/blob/main/readme.md"
+---

--- a/src/posts/keymaps/trguhq.md
+++ b/src/posts/keymaps/trguhq.md
@@ -1,6 +1,6 @@
 ---
 author: trguhq
-baseLayouts: []
+baseLayouts: [Futhark, Colemak, Dvorak, QWERTY]
 firmwares: [QMK]
 hasHomeRowMods: false
 hasLetterOnThumb: false


### PR DESCRIPTION
Adding my layout. Wasn't sure what base layout to put as this does not use Latin letters. AFAIK it is a unique layout but I would call this "Futhark" layout because it is organized into 3 rows of 8 runes as is traditional for the Futhark.