### PR TITLE
Add Desync's Corne Keymap

### DIFF
--- a/src/posts/keymaps/DesyncTheThird.md
+++ b/src/posts/keymaps/DesyncTheThird.md
@@ -16,7 +16,7 @@ keymapImage: https://raw.githubusercontent.com/DesyncTheThird/corne-keymap/main/
 keymapUrl: https://github.com/DesyncTheThird/corne-keymap/tree/main
 languages: English
 layerCount: 13
-OS: Windows
+OS: ["Windows"]
 stagger: columnar
 summary: Keymap for the Corne keyboard, optimised for writing (La)TeX and C files.
 title: Desync's keymap

--- a/src/posts/keymaps/DesyncTheThird.md
+++ b/src/posts/keymaps/DesyncTheThird.md
@@ -1,0 +1,24 @@
+---
+author: DesyncTheThird
+baseLayouts: ["Graphite", "QWERTY"]
+firmwares: [QMK]
+hasHomeRowMods: true
+hasLetterOnThumb: true
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: true
+isSplit: true
+isTapDanceEnabled: false
+keybindings: []
+keyboard: Corne
+keyCount: 42
+keymapImage: https://raw.githubusercontent.com/DesyncTheThird/corne-keymap/main/images/combined.png
+keymapUrl: https://github.com/DesyncTheThird/corne-keymap/tree/main
+languages: English
+layerCount: 13
+OS: Windows
+stagger: columnar
+summary: Keymap for the Corne keyboard, optimised for writing (La)TeX and C files.
+title: Desync's keymap
+writeup: https://github.com/DesyncTheThird/corne-keymap/blob/main/readme.md
+---


### PR DESCRIPTION
Notes:
- I've put Graphite as one of the `baseLayouts`, but it's a slight mod and not quite vanilla Graphite;
- I've put `hasLetterOnThumb` as true, as I have magic keys on thumb keys, but not sure if this counts since all the usual alpha keys are available on non-thumb keys.