### PR TITLE
chore(👊 Knucklehead): update keymap

### DIFF
--- a/src/posts/keymaps/minusfive.md
+++ b/src/posts/keymaps/minusfive.md
@@ -2,14 +2,14 @@
 author: minusfive
 baseLayouts: [Colemak, QWERTY]
 firmwares: [ZMK]
-hasHomeRowMods: false
+hasHomeRowMods: true
 hasLetterOnThumb: false
 hasRotaryEncoder: false
 isAutoShiftEnabled: false
 isComboEnabled: true
 isSplit: true
-isTapDanceEnabled: false
-keybindings: []
+isTapDanceEnabled: true
+keybindings: [Vim]
 keyboard: Corne
 keyCount: 42
 keymapImage: https://minusfive.com/zmk-config/corneish_zen.svg
@@ -18,7 +18,7 @@ languages: [English, Spanish]
 layerCount: 3
 OS: [MacOS, Linux]
 stagger: columnar
-summary: A mnemonic, macOS optimized columnar layout, designed to ease the transition to this style of board for those coming from traditional Apple keyboards.
+summary: A mnemonic, macOS-optimized, 42 key ergonomic columnar layout for corne-style split keyboards, designed to ease the transition from standard ANSI Apple-style keyboards.
 title: 👊 Knucklehead
 writeup: https://github.com/minusfive/zmk-config/blob/main/README.md
 ---

--- a/src/posts/keymaps/minusfive.md
+++ b/src/posts/keymaps/minusfive.md
@@ -1,6 +1,6 @@
 ---
 author: minusfive
-baseLayouts: [Colemak, QWERTY]
+baseLayouts: [Colemak, Dvorak, QWERTY]
 firmwares: [ZMK]
 hasHomeRowMods: true
 hasLetterOnThumb: false


### PR DESCRIPTION
I've switched to using Home Row Mods, tap dances, and `Vim` as my primary editor within the past year, so updating this to reflect that.

**Question:**

I use [Hammerspoon](https://www.hammerspoon.org) to manage my windows, launch apps, and other OS automations. It's not a TWM as I personally dislike TWMs (not for lack of trying), as I prefer to have full control of my layouts.

This setup is fully symbiotic with my keymap, as most apps and window positions/sizes are triggered with a single combo on the base layer.

But that wouldn't count as `TWM` bindings, right?