### PR TITLE
Add keymap for kenkyo.

### DIFF
--- a/src/posts/keymaps/argenkiwi.md
+++ b/src/posts/keymaps/argenkiwi.md
@@ -1,5 +1,5 @@
 ---
-author: Leandro M. Peralta (argenkiwi)
+author: argenkiwi
 baseLayouts: [QWERTY, Colemak, Dvorak]
 firmwares: [Kanata, keyd]
 hasHomeRowMods: true

--- a/src/posts/keymaps/argenkiwi.md
+++ b/src/posts/keymaps/argenkiwi.md
@@ -1,0 +1,24 @@
+---
+author: Leandro M. Peralta (argenkiwi)
+baseLayouts: [QWERTY, Colemak, Dvorak]
+firmwares: [Kanata, keyd]
+hasHomeRowMods: true
+hasLetterOnThumb: false
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: true
+isSplit: true
+isTapDanceEnabled: false
+keybindings: []
+keyboard: ANSI
+keyCount: 31
+keymapImage: https://raw.githubusercontent.com/argenkiwi/kenkyo/refs/heads/main/images/kenkyo.png
+keymapUrl: https://github.com/argenkiwi/kenkyo
+languages: [English, Spanish]
+layerCount: 3
+OS: [Windows, MacOS, Linux]
+stagger: row
+summary: A layered keyboard layout designed to augment your keyboard's capabilities without altering or interfering with its default behaviour, so you can remain productive as you learn to use it.
+title: Kenkyo
+writeup: # not mandatory
+---

--- a/src/posts/keymaps/argenkiwi.md
+++ b/src/posts/keymaps/argenkiwi.md
@@ -20,5 +20,5 @@ OS: [Windows, MacOS, Linux]
 stagger: row
 summary: A layered keyboard layout designed to augment your keyboard's capabilities without altering or interfering with its default behaviour, so you can remain productive as you learn to use it.
 title: Kenkyo
-writeup: # not mandatory
+writeup: https://github.com/argenkiwi/kenkyo/blob/main/README.md
 ---

--- a/src/posts/keymaps/argenkiwi.md
+++ b/src/posts/keymaps/argenkiwi.md
@@ -1,6 +1,6 @@
 ---
 author: argenkiwi
-baseLayouts: [QWERTY, Colemak, Dvorak]
+baseLayouts: [QWERTY, Colemak]
 firmwares: [Kanata, keyd]
 hasHomeRowMods: true
 hasLetterOnThumb: false

--- a/src/posts/keymaps/argenkiwi.md
+++ b/src/posts/keymaps/argenkiwi.md
@@ -7,7 +7,7 @@ hasLetterOnThumb: false
 hasRotaryEncoder: false
 isAutoShiftEnabled: false
 isComboEnabled: true
-isSplit: true
+isSplit: false
 isTapDanceEnabled: false
 keybindings: []
 keyboard: ANSI


### PR DESCRIPTION
A few things to note:
- This layout has been implemented using Kanata and keyd, which are software solutions similar to KMonad.
- This layout was originally designed for ANSI keyboard, but it should pretty much with any keyboard with 30 alpha keys and one thumb key. 

All feedback is welcome. Thanks for your attention and for putting this project together. 