### PR TITLE
Fix image url for the smallcat

### DIFF
--- a/src/posts/keymaps/smallcat.md
+++ b/src/posts/keymaps/smallcat.md
@@ -12,7 +12,7 @@ isTapDanceEnabled: true
 keybindings: [Vim]
 keyboard: Smallcat
 keyCount: 26
-keymapImage: https://github.com/smallwat3r/qmk-keymap/blob/main/images/keymap.png
+keymapImage: https://raw.githubusercontent.com/smallwat3r/qmk-keymap/refs/heads/main/images/keymap.png
 keymapUrl: https://github.com/smallwat3r/qmk-keymap
 languages: [English]
 layerCount: 9


### PR DESCRIPTION
The original url was not returning the PNG itself.