### PR TITLE
Add my Hands Down Promethium layout for an Apple Keyboard

### DIFF
--- a/src/posts/keymaps/peterjc-hands_down_promethium.md
+++ b/src/posts/keymaps/peterjc-hands_down_promethium.md
@@ -1,0 +1,25 @@
+---
+author: peterjc
+baseLayouts: ["Hands Down"]
+firmwares: ["Karabiner-Elements"]
+hasHomeRowMods: false
+hasLetterOnThumb: true
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: true
+isSplit: false
+isTapDanceEnabled: false
+keybindings: []
+keyboard: Japanese Apple KeyBoard
+keyCount: 35
+keymapImage: https://raw.githubusercontent.com/peterjc/kana-chording-ke/main/hands-down-on-jis-macbook.jpeg
+keymapUrl: https://github.com/peterjc/kana-chording-ke/blob/main/hands-down-on-jis-macbook.md
+languages: ["English"]
+layerCount: 2
+OS: ["MacOS"]
+stagger: row
+summary: Remaps the Japanese Apple Keyboard in software to run a variant of the inverted Hands Down Promethium layout, with a navigation layer, combos, and thumb keys. This tries to mimic a split iortholinear keyboard with a double wide-mod.
+# Short summary of max. 60 words
+title: Hands Down Promethium (Pico mod) on Japanese Apple Keyboard
+writeup: https://blastedbio.blogspot.com/2025/05/what-have-you-done-to-your-keyboard.html
+---


### PR DESCRIPTION
See https://github.com/peterjc/kana-chording-ke/blob/main/hands-down-on-jis-macbook.md or blog post https://blastedbio.blogspot.com/2025/05/what-have-you-done-to-your-keyboard.html

This uses Karabiner-Elements (see #82) which is macOS specific, and is intended for an Apple Japanese keyboard, but other Japanese keyboards might work with their extra keys as potential thumb keys...