### PR TITLE
Karabiner-Elements version of the New Stickney Japanese layout

### DIFF
--- a/src/posts/keymaps/peterjc-new_stickney.md
+++ b/src/posts/keymaps/peterjc-new_stickney.md
@@ -1,0 +1,24 @@
+---
+author: peterjc
+baseLayouts: ["QWERTY"]
+firmwares: ["Karabiner-Elements"]
+hasHomeRowMods: false
+hasLetterOnThumb: false
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: false
+isSplit: false
+isTapDanceEnabled: false
+keybindings: []
+keyboard: ANSI
+keyCount: 60
+keymapImage: https://private-user-images.githubusercontent.com/63959/407138342-66dc6791-5262-4835-bd7e-9a15699d9aa3.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTA1MTU2MTIsIm5iZiI6MTc1MDUxNTMxMiwicGF0aCI6Ii82Mzk1OS80MDcxMzgzNDItNjZkYzY3OTEtNTI2Mi00ODM1LWJkN2UtOWExNTY5OWQ5YWEzLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA2MjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNjIxVDE0MTUxMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWNkODdlMzk0YTg5MjkwODI5NWMzMmIyYTI4MzY2ZGZmMjRkOWVhMzljOTYwYjYwYWUzNjg0ODBjMjQzNzJhMjAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.dHffqrwT6XVc83W6lDErw2hbcXJXVweT3kRZHZDwRSc
+keymapUrl: https://codeberg.org/peterjc/kana-chording-ke/src/branch/main/new-stickney-in-macos.md
+languages: ["Japanese"]
+layerCount: 1
+OS: ["MacOS"]
+stagger: "row"
+summary: "A set of Karabiner-Elements mappings to allow the New Stickney Japanese layout to be used (in conjunction with the macOS IME). The layout is supported natively on Linux with the Hiragana IME. It is intended to be more ergonomic with only three rows for the kana than the JIS standard which uses four rows."
+title: "New Stickney Japanese keyboard layout on macOS via Karabiner-Elements"
+writeup: https://codeberg.org/peterjc/kana-chording-ke/src/branch/main/new-stickney-in-macos.md
+---


### PR DESCRIPTION
The New Stickney layout is described here, available on Linux with the Hiragana IME:

https://esrille.github.io/ibus-hiragana/en/layouts.html#new_stickney

This is a Karabiner-Elements mapping to use this layout on macOS with the default macOS IME. This works detecting by remapping keys like `q` so that rather than the IME turning this into "た" as per the JIS layout, Karabiner elements replaces it with `f` to that the IME turns this into "け" as per the New Stickney layout. 