### PR TITLE
Toshihiko Ooka's Japanese Naginata layout (v16)

### DIFF
--- a/src/posts/keymaps/naginata.md
+++ b/src/posts/keymaps/naginata.md
@@ -18,7 +18,7 @@ languages: [Japanese]
 layerCount: 3
 OS: [Windows, MacOS, Linux]
 stagger: ortholinear
-summary: "Kana-based Japanese system for ergonomic keyboards with thumbs-keys, or traditional keyboards with spacebar used as shift. Dakuten (or handakuten) are combos with other hand's index-finger home (or bottom) row. Combos with ya/yu/yo give compound kana (yōon, at most three keys). Punctuation, navigation, and macros are on layers. Currently v16 (2025). Multiple community implementations exist."
+summary: "Kana-based Japanese system for ergonomic keyboards with thumbs-keys, or traditional keyboards with spacebar used as shift. Dakuten (or handakuten) are combos with other hand's index-finger on the home (or bottom) row. Combos with ya/yu/yo give compound kana (yōon, at most three keys). Punctuation, navigation, and macros are on layers. Currently v16 (2025). Multiple community implementations exist."
 title: "Naginata style (薙刀式)"
 writeup: http://oookaworks.seesaa.net/article/456099128.html
 ---


### PR DESCRIPTION
Linking to the community QMK implementation, one of many options, as per discussion on #90.

For the write-up I've linked to the [Naginata layout main page](http://oookaworks.seesaa.net/article/456099128.html) which has all the older versions there too.

I've _linked_ to a [thumbnail of the layout](https://oookaworks.up.seesaa.net/image/E89699E58880E5BC8Fv16E6A0BCE5AD90-thumbnail2.jpg), there is a [larger image](https://oookaworks.up.seesaa.net/image/E89699E58880E5BC8Fv16E6A0BCE5AD90.jpg). Is having the image on this repository preferable?

I've listed the stagger as ortholinear which seems to be the author's personal preference (eg demonstration videos), but "any" would be fair as [traditional row stagger](https://oookaworks.up.seesaa.net/image/v16.jpg) is explicitly supported.