### PR TITLE
added ToyKeeper's Kanata keymap for Logitech K400+

### DIFF
--- a/src/posts/keymaps/toykeeper-kanata_k400plus.md
+++ b/src/posts/keymaps/toykeeper-kanata_k400plus.md
@@ -6,7 +6,7 @@ hasHomeRowMods: false
 hasLetterOnThumb: false
 hasRotaryEncoder: false
 isAutoShiftEnabled: false
-isComboEnabled: true
+isComboEnabled: false
 isSplit: false
 isTapDanceEnabled: false
 keybindings: []


### PR DESCRIPTION
This keymap is intended to make a common mundane keyboard suck less. The K400+ is janky, but for use as a media PC remote control, it has no real competition.  So this keymap aims to make it more tolerable.
