### PR TITLE
Create keymap for Ferris Sweep with Vertical Barring

### DIFF
--- a/src/posts/keymaps/canglong20071221.md
+++ b/src/posts/keymaps/canglong20071221.md
@@ -1,0 +1,31 @@
+---
+author: canglong20071221
+baseLayouts: [QWERTY]
+firmwares: [ZMK]
+hasHomeRowMods: true
+hasLetterOnThumb: false
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: true
+isSplit: true
+isTapDanceEnabled: false
+keybindings: [Vim]
+keyboard: Ferris Sweep
+keyCount: 34
+keymapImage: https://raw.githubusercontent.com/canglong20071221/zmk-config/refs/heads/main/images/my_keymap.svg
+keymapUrl: 
+languages: [English]
+layerCount: 5
+OS: [Windows, MacOS, Linux]
+stagger: columnar
+summary: A "Zero Reach" 34-key layout optimized for low-profile Choc switches. Features a virtual number row via vertical barring (pressing the gap between keys), a mouse layer anchored on the middle finger (Hold-E), and reliable Home Row Mods.
+title: Vertical Barring Sweep
+writeup: |
+  This layout is designed specifically for the Ferris Sweep with low-profile Choc switches and flat keycaps (MBK/CFX). It eliminates the need for reaching or dedicated number layers by using "Vertical Barring"—pressing the gap between two vertical keys to actuate them simultaneously.
+
+  **Key Features:**
+  * **Virtual Numbers:** Q+A=1, W+S=2, etc. (Actuated by pressing the gap).
+  * **Mouse Layer:** Accessed by holding `E` (Left Middle Finger), allowing for stable mouse movement with the right hand (WASD-style on JKLI).
+  * **Navigation:** Vim-style HJKL on a dedicated layer.
+  * **Safety:** Home Row Mods are tuned with `require-prior-idle-ms` to prevent accidental triggers during fast typing.
+---

--- a/src/posts/keymaps/canglong20071221.md
+++ b/src/posts/keymaps/canglong20071221.md
@@ -10,7 +10,7 @@ isComboEnabled: true
 isSplit: true
 isTapDanceEnabled: false
 keybindings: [Vim]
-keyboard: Ferris Sweep
+keyboard: Ferris
 keyCount: 34
 keymapImage: https://raw.githubusercontent.com/canglong20071221/zmk-config/refs/heads/main/images/my_keymap.svg
 keymapUrl: 

--- a/src/posts/keymaps/canglong20071221.md
+++ b/src/posts/keymaps/canglong20071221.md
@@ -12,20 +12,13 @@ isTapDanceEnabled: false
 keybindings: [Vim]
 keyboard: Ferris
 keyCount: 34
-keymapImage: https://raw.githubusercontent.com/canglong20071221/zmk-config/refs/heads/main/images/my_keymap.svg
-keymapUrl: 
+keymapImage: https://raw.githubusercontent.com/canglong20071221/zmk-config/main/images/my_keymap.svg
+keymapUrl: https://github.com/canglong20071221/zmk-config/blob/main/config/cradio.keymap
 languages: [English]
 layerCount: 5
 OS: [Windows, MacOS, Linux]
 stagger: columnar
 summary: A "Zero Reach" 34-key layout optimized for low-profile Choc switches. Features a virtual number row via vertical barring (pressing the gap between keys), a mouse layer anchored on the middle finger (Hold-E), and reliable Home Row Mods.
 title: Vertical Barring Sweep
-writeup: |
-  This layout is designed specifically for the Ferris Sweep with low-profile Choc switches and flat keycaps (MBK/CFX). It eliminates the need for reaching or dedicated number layers by using "Vertical Barring"—pressing the gap between two vertical keys to actuate them simultaneously.
-
-  **Key Features:**
-  * **Virtual Numbers:** Q+A=1, W+S=2, etc. (Actuated by pressing the gap).
-  * **Mouse Layer:** Accessed by holding `E` (Left Middle Finger), allowing for stable mouse movement with the right hand (WASD-style on JKLI).
-  * **Navigation:** Vim-style HJKL on a dedicated layer.
-  * **Safety:** Home Row Mods are tuned with `require-prior-idle-ms` to prevent accidental triggers during fast typing.
+writeup: https://github.com/canglong20071221/zmk-config/blob/main/README.md
 ---

--- a/src/posts/keymaps/canglong20071221.md
+++ b/src/posts/keymaps/canglong20071221.md
@@ -13,7 +13,7 @@ keybindings: [Vim]
 keyboard: Ferris
 keyCount: 34
 keymapImage: https://raw.githubusercontent.com/canglong20071221/zmk-config/main/images/my_keymap.svg
-keymapUrl: https://github.com/canglong20071221/zmk-config/blob/main/config/cradio.keymap
+keymapUrl: https://github.com/canglong20071221/zmk-config/
 languages: [English]
 layerCount: 5
 OS: [Windows, MacOS, Linux]

--- a/src/posts/keymaps/canglong20071221.md
+++ b/src/posts/keymaps/canglong20071221.md
@@ -18,7 +18,7 @@ languages: [English]
 layerCount: 5
 OS: [Windows, MacOS, Linux]
 stagger: columnar
-summary: A "Zero Reach" 34-key layout optimized for low-profile Choc switches. Features a virtual number row via vertical barring (pressing the gap between keys), a mouse layer anchored on the middle finger (Hold-E), and reliable Home Row Mods.
+summary: A “Zero Reach” 34-key layout optimized for low-profile Choc switches. Features a virtual number row via vertical barring (pressing the gap between keys), a mouse layer anchored on the middle finger (Hold-E), and reliable Home Row Mods.
 title: Vertical Barring Sweep
 writeup: https://github.com/canglong20071221/zmk-config/blob/main/README.md
 ---


### PR DESCRIPTION
Added a new keymap for the Ferris Sweep keyboard featuring a unique layout optimized for low-profile Choc switches.