### PR TITLE
Add anymak keymap configuration file

### DIFF
--- a/src/posts/keymaps/anymak.md
+++ b/src/posts/keymaps/anymak.md
@@ -1,0 +1,24 @@
+---
+author: rpnfan
+baseLayouts: ["anymak:END", "Colemak", "QWERTY","Graphite"]  # [QWERTY, Colemak, Dvorak, ...]
+firmwares: [kanata] # [QMK, ZMK, KMonad]
+hasHomeRowMods: false # true or false
+hasLetterOnThumb: false # true or false
+hasRotaryEncoder: false # true or false
+isAutoShiftEnabled: false # true or false
+isComboEnabled: true # true or false
+isSplit: true # true or false
+isTapDanceEnabled: true # true or false
+keybindings: [] # [Vim, Emacs, Kakoune, Graphics/CAD, TWM, Spreadsheets, Gaming]
+keyboard: Corne  # Kyria or Corne or Dactyl Manuform 5x6 or ...
+keyCount: 32
+keymapImage: https://rpnfan.github.io/keyboard-heaven/images/anymak-end.png
+keymapUrl: https://github.com/rpnfan/Anymak
+languages: ["English", "German", "Dutch"] # [English, Spanish, ...]
+layerCount: 3
+OS: ["Windows", "MacOS", "Linux"] # [Windows, MacOS, Linux, Android]
+stagger: columnar # row or columnar or ortholinear
+summary: # Short summary of max. 60 words
+title: anymak:END
+writeup: https://rpnfan.github.io/keyboard-heaven # not mandatory
+---

--- a/src/posts/keymaps/anymak.md
+++ b/src/posts/keymaps/anymak.md
@@ -18,7 +18,7 @@ languages: ["English", "German", "Dutch"] # [English, Spanish, ...]
 layerCount: 3
 OS: ["Windows", "MacOS", "Linux"] # [Windows, MacOS, Linux, Android]
 stagger: columnar # row or columnar or ortholinear
-summary: # Short summary of max. 60 words
+summary: anymak:END is a full system combining a custom alpha layout with an ergonomic layer/modifier framework. The Anymak approach emphasizes one-shot mods, bottom-row mods, SpaceFN (hold space for nav layer with arrows, copy/paste, etc.), and symbol layers. It maintains consistent fingering across standard row-stagger, columnar, and split ergonomic keyboards, avoids uncomfortable positions and prioritizes inward rolls and calm finger flow.
 title: anymak:END
 writeup: https://rpnfan.github.io/keyboard-heaven # not mandatory
 ---


### PR DESCRIPTION
I forgot to add the description, that is, can you add that to the commit?

anymak:END is a full system combining a custom alpha layout with an ergonomic layer/modifier framework. The Anymak approach emphasizes one-shot modifiers, bottom-row mods (e.g., easy-access Shift), SpaceFN (hold space for navigation layer with arrows, copy/paste, etc.), and symbol layers. It maintains consistent fingering across standard row-stagger, columnar, and split ergonomic keyboards, avoids uncomfortable positions and prioritizes inward rolls and calm finger flow. 