### PR TITLE
Add zeitlinger's Magic Keyboard keymap

### DIFF
--- a/src/posts/keymaps/zeitlinger.md
+++ b/src/posts/keymaps/zeitlinger.md
@@ -11,7 +11,7 @@ isSplit: true
 isTapDanceEnabled: false
 keybindings: []
 keyboard: Ferris Sweep
-keyCount: 34
+keyCount: 28
 keymapImage: https://raw.githubusercontent.com/zeitlinger/keyboard/main/keymap.svg
 keymapUrl: https://github.com/zeitlinger/keyboard
 languages: [English]

--- a/src/posts/keymaps/zeitlinger.md
+++ b/src/posts/keymaps/zeitlinger.md
@@ -14,7 +14,7 @@ keyboard: Ferris Sweep
 keyCount: 28
 keymapImage: https://raw.githubusercontent.com/zeitlinger/keyboard/main/keymap.svg
 keymapUrl: https://github.com/zeitlinger/keyboard
-languages: [English]
+languages: [English, German]
 layerCount: 12
 OS: [Linux]
 stagger: columnar

--- a/src/posts/keymaps/zeitlinger.md
+++ b/src/posts/keymaps/zeitlinger.md
@@ -10,7 +10,7 @@ isComboEnabled: true
 isSplit: true
 isTapDanceEnabled: false
 keybindings: []
-keyboard: Ferris Sweep
+keyboard: Ferris
 keyCount: 28
 keymapImage: https://raw.githubusercontent.com/zeitlinger/keyboard/main/keymap.svg
 keymapUrl: https://github.com/zeitlinger/keyboard

--- a/src/posts/keymaps/zeitlinger.md
+++ b/src/posts/keymaps/zeitlinger.md
@@ -1,0 +1,24 @@
+---
+author: zeitlinger
+baseLayouts: ["Hands Down"]
+firmwares: [QMK]
+hasHomeRowMods: false
+hasLetterOnThumb: true
+hasRotaryEncoder: false
+isAutoShiftEnabled: false
+isComboEnabled: true
+isSplit: true
+isTapDanceEnabled: false
+keybindings: []
+keyboard: Ferris Sweep
+keyCount: 34
+keymapImage: https://raw.githubusercontent.com/zeitlinger/keyboard/main/keymap.svg
+keymapUrl: https://github.com/zeitlinger/keyboard
+languages: [English]
+layerCount: 12
+OS: [Linux]
+stagger: columnar
+summary: "34-key Ferris Sweep keymap on Hands Down Vibranium with an alpha thumb. Magic keys finish whole words from context (b+magic → because, t+magic → tion); adaptive keys rewrite same-finger bigrams into rolls (n+r → ng, l+r → ll). QMK firmware generated from markdown tables, packed into flash via a custom 4/8-bit codec."
+title: zeitlinger's Magic Keyboard
+writeup: https://github.com/zeitlinger/keyboard/blob/main/blog/2026-06-13-magic-keyboard.md
+---

--- a/src/posts/keymaps/zeitlinger.md
+++ b/src/posts/keymaps/zeitlinger.md
@@ -18,7 +18,7 @@ languages: [English, German]
 layerCount: 12
 OS: [Linux]
 stagger: columnar
-summary: "34-key Ferris Sweep keymap on Hands Down Vibranium with an alpha thumb. Magic keys finish whole words from context (b+magic → because, t+magic → tion); adaptive keys rewrite same-finger bigrams into rolls (n+r → ng, l+r → ll). QMK firmware generated from markdown tables, packed into flash via a custom 4/8-bit codec."
+summary: "34-key Ferris Sweep keymap on Hands Down Vibranium with an alpha thumb. Magic keys finish whole words from context (b+magic → because); adaptive keys rewrite same-finger bigrams into rolls (n+r → ng, l+r → ll). Low finger travel, in-roll bias, arrows reachable from the home row. No home-row mods — timing-robust, no tap-vs-hold misfires."
 title: zeitlinger's Magic Keyboard
 writeup: https://github.com/zeitlinger/keyboard/blob/main/blog/2026-06-13-magic-keyboard.md
 ---


### PR DESCRIPTION
Submitting my 34-key Ferris Sweep keymap (Hands Down Vibranium base) with magic keys for word completion and adaptive keys for bigram rewriting.

- Layout & generator: https://github.com/zeitlinger/keyboard
- Writeup: https://github.com/zeitlinger/keyboard/blob/main/blog/2026-06-13-magic-keyboard.md