### PR TITLE
argenkiwi: fix keymapImage URL.

### DIFF
--- a/src/posts/keymaps/argenkiwi.md
+++ b/src/posts/keymaps/argenkiwi.md
@@ -12,7 +12,7 @@ isTapDanceEnabled: false
 keybindings: []
 keyboard: ANSI
 keyCount: 31
-keymapImage: https://raw.githubusercontent.com/argenkiwi/kenkyo/refs/heads/main/images/kenkyo.png
+keymapImage: https://raw.githubusercontent.com/argenkiwi/kenkyo/refs/heads/main/images/kenkyo.webp
 keymapUrl: https://github.com/argenkiwi/kenkyo
 languages: [English, Spanish]
 layerCount: 3


### PR DESCRIPTION
Simply fixing a keymap image URL which broke due to its conversion from PNG to WebP.